### PR TITLE
Add multi-profile training and justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,91 @@ The main components are:
 
 ## **Getting Started**
 
+Before you start, make sure you have the following system-level dependencies installed:
+
+1. [**just**](https://just.systems/) - command runner.
+   - Ubuntu/Debian: `sudo apt-get install just`
+   - macOS: `brew install just`
+   - Windows: `winget install just`
+   - Cargo (if you happen to have [Rust](https://rustup.rs)): `cargo install just`
+2. **tmux** - terminal multiplexer (recommended for long-running jobs).
+   - Ubuntu/Debian: `sudo apt-get install tmux`
+   - macOS: `brew install tmux`
+   - Windows: Available through WSL
+3. **Poetry** - Python dependency manager.
+
+Install project dependencies with `poetry install` before proceeding further.
+
 ### **Running the Code**
 
-Install dependencies with `poetry install`
+To start the training process with defined hyperparameters, run `./launcher.sh` (or `just train-local` alias).
+You can specify the number of GPUs to use as an argument: `./launcher.sh 8` (or `just train-local 8`).
 
-To start the training process with defined hyperparameters, execute `launcher.sh`.
-You can specify the number of GPUs to use as an argument: `./launcher.sh 8`
+If you are using Windows, you should use `docker_launcher.ps1` instead. For that, you need to build the Docker image first.
 
-If you are using Windows, you can use `docker_launcher.ps1` instead, in which case you need to build the Docker image first with `build.sh` or `build.ps1` in the `docker` directory. The docker launcher has both Linux (bash) and Windows (PowerShell) variants.
+#### **Training with Docker**
+
+You can use `just docker-build` to build the Docker image (or `build.ps1` in the [`docker`](docker/) directory if you are using Windows). After building the container, you can run the training manually with previously mentioned `docker_launcher.ps1` script if you are using Windows. For Linux or WSL, `just train` runs `docker_launcher.sh` - but there is flexibility:
+
+```bash
+just train [FLAGS]
+
+# Supported flags:
+--gpus=N            Number of GPUs to use
+--visible-gpus=LIST Specific GPUs to use (e.g., "0,1")
+--session=NAME      tmux session name
+-d, --detach        Run in background (tmux)
+
+# Examples:
+just train                      # Use defaults, run in foreground
+just train --gpus=4             # Use 4 GPUs
+just train --visible-gpus="0,1" # Specific GPUs
+just train -d                   # Run in background
+just train --gpus=2 --lr=0.1 -d # Combined usage
+```
+
+#### **Profile-based Training:**
+
+It is possible to run training on a number of different configurations defined as `*.env` files in the [`profiles`](profiles/) directory.
+
+```bash
+profiles/
+  ├── experiment1.env  # e.g., BATCH_SIZE=32, LEARNING_RATE=0.001
+  ├── experiment2.env  # e.g., BATCH_SIZE=64, LEARNING_RATE=0.0005
+  └── experiment3.env  # e.g., BATCH_SIZE=128, LEARNING_RATE=0.0001
+```
+
+Use `just run-profiles` to run training for all profiles. The training script will create a detached tmux session and run the training for each profile.
+
+```bash
+just run-profiles [FLAGS]
+
+# Supported flags:
+--gpus=N           Number of GPUs to use
+--visible-gpus=LIST Specific GPUs to use
+--profiles-dir=DIR Directory containing .env files
+--session=NAME     tmux session name
+
+# Examples:
+just run-profiles                       # Use defaults
+just run-profiles --gpus=4              # Use 4 GPUs
+just run-profiles --visible-gpus="0,1"  # Specific GPUs
+just run-profiles --profiles-dir=exp    # Custom directory
+```
+
+If you need to specify common environment variables for all profiles, you can do by creating a `.env` file (without anything before the dot) in the root of this repository.
+
+#### **Working with tmux Sessions**
+
+```bash
+# View running session
+tmux attach -t nvit
+
+# Inside tmux:
+Ctrl+B, D # Detach from session
+Ctrl+B, [ # Enter scroll mode (use arrow keys)
+q         # Exit scroll mode
+```
 
 ### **Implementation Details**
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The training objective combines several losses with adjustable weights:
 2. **Quantization Loss**
    - Ensures mapped representations stay close to original patches
 
-   $\mathcal{L}_{quant} = \lambda_{lq} \|K_l(P_l) - P_l\|_2^2 + \lambda_{gq} \|K_g(P_g) - P_g\|_2^2$
+   $\mathcal{L}_{quant} = \lambda _{lq} \|K_l(P_l) - P_l\|_2^2 + \lambda _{gq} \|K_g(P_g) - P_g\|_2^2$
    
    where $K_l$ and $K_g$ are local and global Kohonen maps
    $\lambda_{lq} = \lambda_{gq} = 0.1$ (default weights)
@@ -203,7 +203,7 @@ The training objective combines several losses with adjustable weights:
 
 The final loss combines all components:
 
-$\mathcal{L}_{total} = \mathcal{L}_{cls} + \mathcal{L}_{quant} + \mathcal{L}_{cons} + \mathcal{L}_{smooth} + \mathcal{L}_{rec}$
+$\mathcal{L}_{total} = \mathcal{L} _{cls} + \mathcal{L} _{quant} + \mathcal{L} _{cons} + \mathcal{L} _{smooth} + \mathcal{L} _{rec}$
 
 #### **Training Dynamics**
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,92 @@
+#!/usr/bin/env just --justfile
+
+# tmux session name
+session := env_var_or_default("SESSION", "nvit")
+
+default:
+    @just --list
+
+install:
+    poetry install
+
+train-local *ARGS:
+    #!/usr/bin/env bash
+    use_tmux=false
+    args=""
+
+    for arg in {{ARGS}}; do
+        if [ "$arg" = "-d" ] || [ "$arg" = "--detach" ]; then
+            use_tmux=true
+        else
+            args="$args $arg"
+        fi
+    done
+
+    if [ "$use_tmux" = true ]; then
+        if ! tmux has-session -t {{session}} 2>/dev/null; then
+            tmux new-session -d -s {{session}}
+        fi
+        tmux send-keys -t {{session}} "./launcher.sh $args" Enter
+        echo "Training started in tmux session '{{session}}'. Use 'tmux attach -t {{session}}' to view."
+        echo "When attached, press Ctrl+B, D to detach from the session."
+    else
+        ./launcher.sh $args
+    fi
+
+docker-build:
+    cd docker && ./build.sh
+
+train *ARGS:
+    #!/usr/bin/env bash
+    use_tmux=false
+    args=""
+
+    for arg in {{ARGS}}; do
+        if [ "$arg" = "-d" ] || [ "$arg" = "--detach" ]; then
+            use_tmux=true
+        else
+            args="$args $arg"
+        fi
+    done
+    
+    cmd="./docker_launcher.sh $args"
+    
+    if [ "$use_tmux" = true ]; then
+        if ! tmux has-session -t {{session}} 2>/dev/null; then
+            tmux new-session -d -s {{session}}
+        fi
+        tmux send-keys -t {{session}} "$cmd" Enter
+        echo "Training started in tmux session '{{session}}'. Use 'tmux attach -t {{session}}' to view."
+        echo "When attached, press Ctrl+B, D to detach from the session."
+    else
+        $cmd
+    fi
+
+run-profiles *ARGS:
+    #!/usr/bin/env bash
+    use_tmux=false
+    args=""
+
+    for arg in {{ARGS}}; do
+        if [ "$arg" = "-d" ] || [ "$arg" = "--detach" ]; then
+            use_tmux=true
+        else
+            args="$args $arg"
+        fi
+    done
+
+    if [ "$use_tmux" = true ]; then
+        if ! tmux has-session -t {{session}} 2>/dev/null; then
+            tmux new-session -d -s {{session}}
+        fi
+        tmux send-keys -t {{session}} "./run_profiles.sh $args" Enter
+        echo "Profile training started in tmux session '{{session}}'. Use 'tmux attach -t {{session}}' to view."
+        echo "When attached, press Ctrl+B, D to detach from the session."
+    else
+        ./run_profiles.sh $args
+    fi
+
+clean:
+    rm -rf .cache
+    find . -type d -name "__pycache__" -exec rm -rf {} +
+    find . -type f -name "*.pyc" -delete

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# read number of GPUs from args on command line, if present, otherwise default to 8
 num_gpus=$1
 
 if [ -z "$num_gpus" ]; then

--- a/run_profiles.sh
+++ b/run_profiles.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+num_gpus=1
+visible_gpus="all"
+profiles_dir="profiles"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --num_gpus)
+            num_gpus="$2"
+            shift 2
+            ;;
+        --visible_gpus)
+            visible_gpus="$2"
+            shift 2
+            ;;
+        --profiles-dir)
+            profiles_dir="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+env_files=("$profiles_dir"/*.env)
+if [ ${#env_files[@]} -eq 0 ] || [ ! -e "${env_files[0]}" ]; then
+    echo "No .env files found in $profiles_dir directory"
+    exit 1
+fi
+
+# Read .env file if it exists and prepend it to the profile env files
+local_env=""
+if [ -f ".env" ]; then
+    local_env=$(cat .env)
+fi
+
+for env_file in "${env_files[@]}"; do
+    echo "Profile: $env_file"
+    profile_env=$(cat "$env_file")
+
+    ./docker_launcher.sh \
+        --num_gpus "$num_gpus" \
+        --visible_gpus "$visible_gpus" \
+        --env-file <(echo -e "${local_env}\n${profile_env}")
+done


### PR DESCRIPTION
Introduce `justfile` which eases running training, and introduce multi-profile training by executing a run per each `*.env` file in `profiles/` directory.

Notice that `just train -d` has intentionally different semantics to `./docker_launcher.sh -d` - the former spawns a detached tmux session, while the latter runs a detached container.